### PR TITLE
Add docker-compose for core services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.9'
+
+services:
+  orchestrator:
+    image: tiangolo/uvicorn-gunicorn-fastapi:python3.11
+    container_name: orchestrator
+    volumes:
+      - ./app:/app
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/vision
+      REDIS_URL: redis://redis:6379/0
+      QDRANT_URL: http://qdrant:6333
+    ports:
+      - "8000:80"
+    depends_on:
+      - redis
+      - qdrant
+    networks:
+      - vision_core
+
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
+    networks:
+      - vision_core
+
+  qdrant:
+    image: qdrant/qdrant
+    container_name: qdrant
+    volumes:
+      - qdrant_data:/qdrant/storage
+    ports:
+      - "6333:6333"
+    networks:
+      - vision_core
+
+volumes:
+  qdrant_data:
+
+networks:
+  vision_core:
+    external: true


### PR DESCRIPTION
## Summary
- add docker-compose.yml defining orchestrator, redis and qdrant services
- join an external network to connect to an existing postgres container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684946d2b0a0832cb69a915c20fdcf90