### PR TITLE
Add docker secrets example and Makefile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment configuration for local development
+# Real secrets should be provided via a secret manager such as Vault or Doppler
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/vision
+REDIS_URL=redis://redis:6379/0
+QDRANT_URL=http://qdrant:6333

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: dev test compose-up lint
+
+dev:
+	docker-compose up orchestrator
+
+compose-up:
+	docker-compose up -d
+
+test:
+	pytest -q
+
+lint:
+	echo "No linting configured"

--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ MultiAgent Intelligence Hub
 This repository includes configuration for a development container targeting Python 3.11. The dev container can be built using the files under `.devcontainer/`.
 
 A basic GitHub Actions workflow is provided to run tests with `pytest -q` on every push.
+
+## Secrets management
+
+Environment variables for the services are loaded from a `.env` file. An example configuration is provided in `.env.example`. For real deployments, secrets should be injected via Vault or Doppler rather than committed to version control.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.9'
+
+services:
+  orchestrator:
+    image: tiangolo/uvicorn-gunicorn-fastapi:python3.11
+    container_name: orchestrator
+    volumes:
+      - ./app:/app
+    env_file:
+      - .env
+    ports:
+      - "8000:80"
+    depends_on:
+      - redis
+      - qdrant
+    networks:
+      - vision_core
+
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
+    networks:
+      - vision_core
+
+  qdrant:
+    image: qdrant/qdrant
+    container_name: qdrant
+    volumes:
+      - qdrant_data:/qdrant/storage
+    ports:
+      - "6333:6333"
+    networks:
+      - vision_core
+
+volumes:
+  qdrant_data:
+
+networks:
+  vision_core:
+    external: true


### PR DESCRIPTION
## Summary
- pull environment variables from `.env` in docker-compose
- add `.env.example` for local configuration
- include basic Makefile with common targets
- document secrets management in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684946d2b0a0832cb69a915c20fdcf90